### PR TITLE
fix: Add await to pop() when existing fullscreen

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/methods/fullscreen.dart
@@ -73,7 +73,7 @@ Future<void> exitFullscreen(BuildContext context) {
   return lock.synchronized(() async {
     if (isFullscreen(context)) {
       if (context.mounted) {
-        Navigator.of(context).maybePop();
+        await Navigator.of(context).maybePop();
         // It is known that this [context] will have a [FullscreenInheritedWidget] above it.
         FullscreenInheritedWidget.of(context).parent.refreshView();
       }


### PR DESCRIPTION
Adds await to exitFullscreen() removing race condition? when trying to exit fullscreen and then pop the context of another widget.